### PR TITLE
Add resource engine interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY engines/ engines/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Stack template engine
+
+## Developing
+
+### Testing
+
+There are some rudimentary integration tests.
+
+To start the controller locally, run:
+
+```
+make run
+```
+
+Then, in another window, run:
+
+```
+make integration-test
+```
+
+It should create a config map named `mycustomname-{{ engine }}`. So, for
+example, `mycustomname-helm2` for the helm 2 integration test.
+
+To clean up, run:
+
+```
+make clean-integration-test
+```
+
+The source files for the integration tests are in `test/`.
+
+To debug the integration test, inspect the logs for any jobs or pods
+which were run by the controller. Also take a look at the controller's
+logs.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,23 @@
 
 There are some rudimentary integration tests.
 
-To start the controller locally, run:
+First, build the stack:
+
+```
+kubectl crossplane stack build
+```
+
+This is the most convenient way to get the contents of the stack into
+the cluster.
+
+Next, start the controller locally:
 
 ```
 make run
 ```
 
-Then, in another window, run:
+Then, in another window, run the integration test to build all the
+helpers and create test objects:
 
 ```
 make integration-test
@@ -27,7 +37,8 @@ To clean up, run:
 make clean-integration-test
 ```
 
-The source files for the integration tests are in `test/`.
+The source files for the integration tests are in `test/` and in the
+`Makefile`.
 
 To debug the integration test, inspect the logs for any jobs or pods
 which were run by the controller. Also take a look at the controller's

--- a/config/stack/manifests/install.yaml
+++ b/config/stack/manifests/install.yaml
@@ -16,8 +16,8 @@ spec:
         core.crossplane.io/name: "crossplane-stack-helm"
     spec:
       containers:
-      - name: "crossplane-stack-helm-controller"
-        image: "crossplane/stack-helm"
+      - name: "crossplane-stack-template-engine-controller"
+        image: "crossplane/stack-template-engine"
         env:
         - name: POD_NAME
           valueFrom:

--- a/controllers/renderphase_controller.go
+++ b/controllers/renderphase_controller.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/suskin/stack-template-engine/api/v1alpha1"
-	helmv1alpha1 "github.com/suskin/stack-template-engine/api/v1alpha1"
 )
 
 // RenderPhaseReconciler reconciles an object which we're watching for a template stack
@@ -49,6 +48,91 @@ const (
 	renderTimeout = 60 * time.Second
 	spec          = "spec"
 )
+
+type ResourceEngineRunner interface {
+	CreateConfig(
+		claim *unstructured.Unstructured,
+		hc *v1alpha1.HookConfiguration,
+		// engine type
+
+	) (*corev1.ConfigMap, error)
+	// ) (string fileName, string fileContents)
+	RunEngine(
+		claim *unstructured.Unstructured,
+		config *corev1.ConfigMap,
+	) error // (result, error)
+}
+
+type Helm2EngineRunner struct {
+	Log logr.Logger
+}
+
+// When a behavior executes, the resource engine is configured by the
+// object which triggered the behavior. This method encapsulates the logic to
+// create the resource engine configuration from the object's fields.
+func (her *Helm2EngineRunner) CreateConfig(claim *unstructured.Unstructured, hc *v1alpha1.HookConfiguration) (*corev1.ConfigMap, error) {
+	// yamlyamlyamlyamlyaml
+	// TODO if spec is missing, this won't work very well
+	s, ok := claim.Object[spec]
+
+	if !ok {
+		her.Log.V(0).Info("Spec not found on claim; not creating engine configuration", "claim", claim)
+	}
+
+	her.Log.V(0).Info("Converting configuration", "spec", s)
+	configContents, err := yaml.Marshal(s)
+
+	her.Log.V(0).Info("Configuration contents as yaml", "configContents", configContents)
+
+	if err != nil {
+		her.Log.Error(err, "Error marshaling claim spec as yaml!", "claim", claim)
+		return nil, err
+	}
+
+	// Underneath, the yamler uses https://godoc.org/encoding/json#Marshal,
+	// which means that the bytes are UTF-8 encoded
+	// Theoretically we could get better performance by using a binary config
+	// map, but having a string makes it better for humans who may want to observe
+	// or troubleshoot behavior.
+	stringConfigContents := string(configContents)
+
+	// TODO get the engine type from the configuration
+	engineType := hc.Engine.Type
+
+	// TODO engine type should have a bit more structure;
+	// probably better to use an enum type pattern, with an
+	// engine name and its corresponding configuration file
+	// name in the same object
+	configKeyName := ""
+
+	if engineType == "helm2" {
+		configKeyName = "values.yaml"
+	}
+
+	configName := string(claim.GetUID())
+	generatedMap, err := generateConfigMap(configName, configKeyName, stringConfigContents, her.Log)
+
+	if err != nil {
+		her.Log.V(0).Info("Error generating config map!", "claim", claim, "error", err)
+		return nil, err
+	}
+
+	generatedMap.SetNamespace(claim.GetNamespace())
+
+	her.Log.V(0).Info("Generated config map to pass engine configuration", "configMap", generatedMap)
+
+	return generatedMap, err
+}
+
+func (her *Helm2EngineRunner) RunEngine(claim *unstructured.Unstructured, config *corev1.ConfigMap) error {
+	return nil
+}
+
+func NewHelm2EngineRunner(log logr.Logger) *Helm2EngineRunner {
+	return &Helm2EngineRunner{
+		Log: log,
+	}
+}
 
 // +kubebuilder:rbac:groups=helm.samples.stacks.crossplane.io,resources=helmchartinstalls,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=helm.samples.stacks.crossplane.io,resources=helmchartinstalls/status,verbs=get;update;patch
@@ -117,23 +201,58 @@ func (r *RenderPhaseReconciler) render(ctx context.Context, claim *unstructured.
 	}
 
 	for _, hookCfg := range trb {
-		engineCfg, err := r.createBehaviorEngineConfiguration(ctx, claim, &hookCfg)
+		engineType := hookCfg.Engine.Type
+
+		var engineRunner ResourceEngineRunner
+
+		// TODO this should probably not be a hard-coded raw string
+		if engineType == "helm2" {
+			engineRunner = NewHelm2EngineRunner(r.Log)
+		} else {
+			r.Log.V(0).Info("Unrecognized engine type! Skipping hook.", "claim", claim, "hookConfig", hookCfg)
+			continue
+		}
+
+		cm, err := engineRunner.CreateConfig(claim, &hookCfg)
+
+		// engineCfg, err := r.createBehaviorEngineConfiguration(ctx, claim, &hookCfg)
 
 		if err != nil {
-			r.Log.Error(err, "Error creating engine configuration!", "claim", claim, "hook config", hookCfg)
+			r.Log.Error(err, "Error creating engine configuration!", "claim", claim, "hookConfig", hookCfg)
+			return err
+		}
+
+		err = r.createConfigMap(ctx, cm)
+		if err != nil {
+			r.Log.Error(err, "Error creating config map!", "claim", claim, "hookConfig", hookCfg)
 			return err
 		}
 
 		// TODO support specifying the image on the hook
 		stackImage := cfg.Spec.Behaviors.Source.Image
 
-		result, err := r.executeHook(ctx, claim, engineCfg, stackImage, &hookCfg)
+		result, err := r.executeHook(ctx, claim, cm, stackImage, &hookCfg)
 		// TODO check for errors
 
 		err = r.setClaimStatus(claim, result)
 	}
 
 	return err
+}
+
+// This mostly exists to encapsulate the logging and the ignoring of already exists errors
+func (r *RenderPhaseReconciler) createConfigMap(ctx context.Context, cm *corev1.ConfigMap) error {
+	if err := r.Client.Create(ctx, cm); err != nil {
+		if kerrors.IsAlreadyExists(err) {
+			r.Log.V(1).Info("Config map already exists! Ignoring error", "configMap", cm)
+		} else {
+			// One might consider logging an error here, but the logging is handled at a higher level
+			// where more context can be logged.
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *RenderPhaseReconciler) getStackConfiguration(
@@ -233,78 +352,8 @@ func (r *RenderPhaseReconciler) getBehavior(
 	return resolvedCfgs, nil
 }
 
-// When a behavior executes, the resource engine is configured by the
-// object which triggered the behavior. This method encapsulates the logic to
-// create the resource engine configuration from the object's fields.
-func (r *RenderPhaseReconciler) createBehaviorEngineConfiguration(
-	ctx context.Context,
-	claim *unstructured.Unstructured,
-	hc *v1alpha1.HookConfiguration,
-) (*corev1.ConfigMap, error) {
-	// yamlyamlyamlyamlyaml
-	// TODO if spec is missing, this won't work very well
-	s, ok := claim.Object[spec]
-
-	if !ok {
-		r.Log.V(0).Info("Spec not found on claim; not creating engine configuration", "claim", claim)
-	}
-
-	r.Log.V(0).Info("Converting configuration", "spec", s)
-	configContents, err := yaml.Marshal(s)
-
-	r.Log.V(0).Info("Configuration contents as yaml", "configContents", configContents)
-
-	if err != nil {
-		r.Log.Error(err, "Error marshaling claim spec as yaml!", "claim", claim)
-		return nil, err
-	}
-
-	// Underneath, the yamler uses https://godoc.org/encoding/json#Marshal,
-	// which means that the bytes are UTF-8 encoded
-	// Theoretically we could get better performance by using a binary config
-	// map, but having a string makes it better for humans who may want to observe
-	// or troubleshoot behavior.
-	stringConfigContents := string(configContents)
-
-	// TODO get the engine type from the configuration
-	engineType := hc.Engine.Type
-
-	// TODO engine type should have a bit more structure;
-	// probably better to use an enum type pattern, with an
-	// engine name and its corresponding configuration file
-	// name in the same object
-	configKeyName := ""
-
-	if engineType == "helm2" {
-		configKeyName = "values.yaml"
-	}
-
-	configName := string(claim.GetUID())
-	generatedMap, err := r.generateConfigMap(configName, configKeyName, stringConfigContents)
-
-	if err != nil {
-		r.Log.V(0).Info("Error generating config map!", "claim", claim, "error", err)
-		return nil, err
-	}
-
-	generatedMap.SetNamespace(claim.GetNamespace())
-
-	r.Log.V(0).Info("Generated config map to pass engine configuration", "configMap", generatedMap)
-
-	if err := r.Client.Create(ctx, generatedMap); err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			r.Log.V(1).Info("Config map already exists! Ignoring error", "claim", claim, "configMap", generatedMap)
-		} else {
-			r.Log.V(0).Info("Error creating config map!", "claim", claim, "error", err, "configMap", generatedMap)
-			return nil, err
-		}
-	}
-
-	return generatedMap, err
-}
-
 // The main reason this exists as its own method is to encapsulate the hashing logic
-func (r *RenderPhaseReconciler) generateConfigMap(name string, fileName string, fileContents string) (*corev1.ConfigMap, error) {
+func generateConfigMap(name string, fileName string, fileContents string, log logr.Logger) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{}
 	cm.Name = name
 	cm.Data = map[string]string{}
@@ -312,7 +361,7 @@ func (r *RenderPhaseReconciler) generateConfigMap(name string, fileName string, 
 	cm.Data[fileName] = fileContents
 	h, err := hash.ConfigMapHash(cm)
 	if err != nil {
-		r.Log.V(0).Info("Error hashing config map!", "error", err)
+		log.V(0).Info("Error hashing config map!", "error", err)
 		return cm, err
 	}
 	cm.Name = fmt.Sprintf("%s-%s", cm.Name, h)
@@ -489,10 +538,4 @@ func (r *RenderPhaseReconciler) setClaimStatus(
 	// If the processing happens in a job, the status should be updated after the job completes, which may mean
 	// waiting for it to complete by using a watcher.
 	return nil
-}
-
-func (r *RenderPhaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&helmv1alpha1.HelmChartInstall{}).
-		Complete(r)
 }

--- a/engines/helm2.go
+++ b/engines/helm2.go
@@ -15,9 +15,16 @@ limitations under the License.
 package engines
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
 	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	"github.com/suskin/stack-template-engine/api/v1alpha1"
@@ -89,8 +96,157 @@ func (her *Helm2EngineRunner) CreateConfig(claim *unstructured.Unstructured, hc 
 	return generatedMap, err
 }
 
-func (her *Helm2EngineRunner) RunEngine(claim *unstructured.Unstructured, config *corev1.ConfigMap) error {
-	return nil
+// TODO we could potentially have a method create the job, and a higher-level one execute it.
+func (her *Helm2EngineRunner) RunEngine(ctx context.Context, client client.Client, claim *unstructured.Unstructured, config *corev1.ConfigMap, stackSource string, hc *v1alpha1.HookConfiguration) (*unstructured.Unstructured, error) {
+	// TODO if there is no config specified, either use an empty config or don't specify
+	// one at all.
+
+	// TODO if we change this to meta.AsController, and we have the controller-runtime controller configured
+	// to Own Jobs, then we'll get a reconcile call when Jobs finish. However, we'd need to change the logic
+	// for the reconcile a bit to support that effectively. For example:
+	// - We wouldn't want to create jobs every time reconcile is run
+	//   * This means keeping track of created jobs somewhere and could also mean using deterministic job names
+	ownerRef := meta.AsOwner(meta.ReferenceTo(claim, claim.GroupVersionKind()))
+	var jobBackoff int32
+
+	// TODO target stack image will come from the stack object, or maybe the stack install object.
+	// Then for each resource behavior hook, we want to run the hook
+	// TODO update this to use the most recent format, where a hook is a structured object
+
+	resourceDir := fmt.Sprintf("/.registry/resources/%s", hc.Directory)
+
+	engineCfgVolumeName := "engine-configuration"
+	engineCfgDir := "/usr/share/engine-configuration/"
+
+	// TODO this file name should not be hard-coded
+	engineCfgFile := fmt.Sprintf("%svalues.yaml", engineCfgDir)
+
+	stackVolumeName := "stack-configuration"
+	stackDestDir := "/usr/share/input/"
+
+	resourceCfgVolumeName := "resource-configuration"
+	resourceCfgDestDir := "/usr/share/resource-configuration/"
+	namespace := claim.GetNamespace()
+
+	// TODO we should generate a name and save a reference on the claim
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "helm-template-apply-",
+			Namespace:    namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				ownerRef,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &jobBackoff,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					InitContainers: []corev1.Container{
+						{
+							Name:  "load-stack",
+							Image: stackSource,
+							Command: []string{
+								// The "." suffix causes the cp -R to copy the contents of the directory instead of
+								// the directory itself
+								"cp", "-R", fmt.Sprintf("%s/.", resourceDir), stackDestDir,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      stackVolumeName,
+									MountPath: stackDestDir,
+								},
+							},
+							ImagePullPolicy: corev1.PullNever,
+						},
+						{
+							Name:  "engine",
+							Image: "crossplane/helm-engine:latest",
+							Command: []string{
+								"helm",
+							},
+							Args: []string{
+								"template",
+								"--output-dir", resourceCfgDestDir,
+								"--namespace", namespace,
+								"--values", engineCfgFile,
+								stackDestDir,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      stackVolumeName,
+									MountPath: stackDestDir,
+								},
+								{
+									Name:      resourceCfgVolumeName,
+									MountPath: resourceCfgDestDir,
+								},
+								{
+									Name:      engineCfgVolumeName,
+									MountPath: engineCfgDir,
+								},
+							},
+							ImagePullPolicy: corev1.PullNever,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "kubectl",
+							Image: "crossplane/kubectl:latest",
+							// "--debug" can be added to this list of Args to get debug output from the job,
+							// but note that will be included in the stdout from the pod, which makes it
+							// impossible to create the resources that the job unpacks.
+							Command: []string{
+								"kubectl",
+							},
+							Args: []string{
+								"apply",
+								"--namespace", namespace,
+								"-R",
+								"-f",
+								resourceCfgDestDir,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      resourceCfgVolumeName,
+									MountPath: resourceCfgDestDir,
+								},
+							},
+							ImagePullPolicy: corev1.PullNever,
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: stackVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: resourceCfgVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: engineCfgVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: config.GetName(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// TODO theoretically this won't be creating a job every time, and eventually we'll want to return a status or result of some sort
+	// so that our shared reconciler logic can expose it, probably by updating the claim status.
+	return nil, client.Create(ctx, job)
 }
 
 func NewHelm2EngineRunner(log logr.Logger) *Helm2EngineRunner {

--- a/engines/helm2.go
+++ b/engines/helm2.go
@@ -113,7 +113,7 @@ func (her *Helm2EngineRunner) RunEngine(ctx context.Context, client client.Clien
 	// Then for each resource behavior hook, we want to run the hook
 	// TODO update this to use the most recent format, where a hook is a structured object
 
-	resourceDir := fmt.Sprintf("/.registry/resources/%s", hc.Directory)
+	resourceDir := fmt.Sprintf("/.registry/%s", hc.Directory)
 
 	engineCfgVolumeName := "engine-configuration"
 	engineCfgDir := "/usr/share/engine-configuration/"

--- a/engines/helm2.go
+++ b/engines/helm2.go
@@ -1,0 +1,100 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package engines
+
+import (
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/suskin/stack-template-engine/api/v1alpha1"
+)
+
+type Helm2EngineRunner struct {
+	Log logr.Logger
+}
+
+const (
+	spec = "spec"
+)
+
+// When a behavior executes, the resource engine is configured by the
+// object which triggered the behavior. This method encapsulates the logic to
+// create the resource engine configuration from the object's fields.
+// TODO it seems as though a lot of the transformation logic is probably reusable
+func (her *Helm2EngineRunner) CreateConfig(claim *unstructured.Unstructured, hc *v1alpha1.HookConfiguration) (*corev1.ConfigMap, error) {
+	// yamlyamlyamlyamlyaml
+	// TODO if spec is missing, this won't work very well
+	s, ok := claim.Object[spec]
+
+	if !ok {
+		her.Log.V(0).Info("Spec not found on claim; not creating engine configuration", "claim", claim)
+	}
+
+	her.Log.V(0).Info("Converting configuration", "spec", s)
+	configContents, err := yaml.Marshal(s)
+
+	her.Log.V(0).Info("Configuration contents as yaml", "configContents", configContents)
+
+	if err != nil {
+		her.Log.Error(err, "Error marshaling claim spec as yaml!", "claim", claim)
+		return nil, err
+	}
+
+	// Underneath, the yamler uses https://godoc.org/encoding/json#Marshal,
+	// which means that the bytes are UTF-8 encoded
+	// Theoretically we could get better performance by using a binary config
+	// map, but having a string makes it better for humans who may want to observe
+	// or troubleshoot behavior.
+	stringConfigContents := string(configContents)
+
+	// TODO get the engine type from the configuration
+	engineType := hc.Engine.Type
+
+	// TODO engine type should have a bit more structure;
+	// probably better to use an enum type pattern, with an
+	// engine name and its corresponding configuration file
+	// name in the same object
+	configKeyName := ""
+
+	if engineType == "helm2" {
+		configKeyName = "values.yaml"
+	}
+
+	configName := string(claim.GetUID())
+	generatedMap, err := generateConfigMap(configName, configKeyName, stringConfigContents, her.Log)
+
+	if err != nil {
+		her.Log.V(0).Info("Error generating config map!", "claim", claim, "error", err)
+		return nil, err
+	}
+
+	generatedMap.SetNamespace(claim.GetNamespace())
+
+	her.Log.V(0).Info("Generated config map to pass engine configuration", "configMap", generatedMap)
+
+	return generatedMap, err
+}
+
+func (her *Helm2EngineRunner) RunEngine(claim *unstructured.Unstructured, config *corev1.ConfigMap) error {
+	return nil
+}
+
+func NewHelm2EngineRunner(log logr.Logger) *Helm2EngineRunner {
+	return &Helm2EngineRunner{
+		Log: log,
+	}
+}

--- a/engines/resource_engines.go
+++ b/engines/resource_engines.go
@@ -1,0 +1,36 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package engines
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/suskin/stack-template-engine/api/v1alpha1"
+)
+
+type ResourceEngineRunner interface {
+	CreateConfig(
+		claim *unstructured.Unstructured,
+		hc *v1alpha1.HookConfiguration,
+		// engine type
+
+	) (*corev1.ConfigMap, error)
+	// ) (string fileName, string fileContents)
+	RunEngine(
+		claim *unstructured.Unstructured,
+		config *corev1.ConfigMap,
+	) error // (result, error)
+}

--- a/engines/resource_engines.go
+++ b/engines/resource_engines.go
@@ -15,8 +15,11 @@ limitations under the License.
 package engines
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/suskin/stack-template-engine/api/v1alpha1"
 )
@@ -30,7 +33,11 @@ type ResourceEngineRunner interface {
 	) (*corev1.ConfigMap, error)
 	// ) (string fileName, string fileContents)
 	RunEngine(
+		ctx context.Context,
+		client client.Client,
 		claim *unstructured.Unstructured,
 		config *corev1.ConfigMap,
-	) error // (result, error)
+		stackSource string,
+		hc *v1alpha1.HookConfiguration,
+	) (*unstructured.Unstructured, error)
 }

--- a/engines/resource_engines.go
+++ b/engines/resource_engines.go
@@ -24,14 +24,23 @@ import (
 	"github.com/suskin/stack-template-engine/api/v1alpha1"
 )
 
+// A ResourceEngineRunner is responsible for creating resources for a template stack when a hook is executed.
+//
+// The inputs are:
+// - A hook configuration
+// - The object which triggered this hook
+// - The source files to create resources from
+//
+// The outputs should be:
+// - Created resources
+//
+// This interface is still fairly new; in the future we'll want to be able to represent the status of the resources
+// which are being created. For example, if the resources are created asynchronously (say by running a Job), the
+// output the first time the engine is run may be the status of the Job. The next time, if the job is finished, it may
+// be some sort of reference to the objects which have been created.
 type ResourceEngineRunner interface {
-	CreateConfig(
-		claim *unstructured.Unstructured,
-		hc *v1alpha1.HookConfiguration,
-		// engine type
+	CreateConfig(claim *unstructured.Unstructured, hc *v1alpha1.HookConfiguration) (*corev1.ConfigMap, error)
 
-	) (*corev1.ConfigMap, error)
-	// ) (string fileName, string fileContents)
 	RunEngine(
 		ctx context.Context,
 		client client.Client,

--- a/engines/util.go
+++ b/engines/util.go
@@ -1,0 +1,41 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engines
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubectl/pkg/util/hash"
+)
+
+// The main reason this exists as its own method is to encapsulate the hashing logic
+func generateConfigMap(name string, fileName string, fileContents string, log logr.Logger) (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	cm.Name = name
+	cm.Data = map[string]string{}
+
+	cm.Data[fileName] = fileContents
+	h, err := hash.ConfigMapHash(cm)
+	if err != nil {
+		log.V(0).Info("Error hashing config map!", "error", err)
+		return cm, err
+	}
+	cm.Name = fmt.Sprintf("%s-%s", cm.Name, h)
+
+	return cm, nil
+}

--- a/stack.Dockerfile
+++ b/stack.Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY engines/ engines/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/stack.env
+++ b/stack.env
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-STACK_IMG ?= crossplane/stack-helm:latest
+STACK_IMG ?= crossplane/stack-template-engine:latest
 
 CRD_DIR ?= config/crd/bases
 STACK_PACKAGE_REGISTRY_SOURCE ?= config/stack/manifests

--- a/test/helm2/Dockerfile
+++ b/test/helm2/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.7
+
+WORKDIR /.registry
+
+COPY stack.yaml stack.yaml
+COPY resources resources

--- a/test/helm2/resources/.helmignore
+++ b/test/helm2/resources/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/test/helm2/resources/Chart.yaml
+++ b/test/helm2/resources/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.0.1"
+description: A sample Helm chart
+name: sample-template-stack
+version: 0.0.1

--- a/test/helm2/resources/templates/NOTES.txt
+++ b/test/helm2/resources/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Release: {{.Release.Name}}
+
+Chart Name: {{.Chart.Name}}
+Chart Description: {{.Chart.Description}}
+Chart Version: {{.Chart.Version}}
+Chart API Version: {{.Chart.ApiVersion}}
+Chart Application Version: {{.Chart.AppVersion}}
+
+Kube Version: {{.Capabilities.KubeVersion}}
+Tiller Version: {{.Capabilities.TillerVersion}}

--- a/test/helm2/resources/templates/_helpers.tpl
+++ b/test/helm2/resources/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/test/helm2/resources/templates/configmap.yaml
+++ b/test/helm2/resources/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "name" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  configmode: {{ .Values.config.mode }}

--- a/test/helm2/resources/values.yaml
+++ b/test/helm2/resources/values.yaml
@@ -1,0 +1,2 @@
+config:
+    mode: release

--- a/test/helm2/sample-cr.yaml
+++ b/test/helm2/sample-cr.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: samples.stacks.crossplane.io/v1alpha1
+kind: SampleClaim
+metadata:
+  name: sample-claim-test
+spec:
+  config:
+    mode: debug
+  nameOverride: mycustomname-helm2

--- a/test/helm2/sample-crd.yaml
+++ b/test/helm2/sample-crd.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: sampleclaims.samples.stacks.crossplane.io
+spec:
+  group: samples.stacks.crossplane.io
+  names:
+    kind: SampleClaim
+    plural: sampleclaims
+  scope: ""
+  validation:
+    openAPIV3Schema:
+      description: SampleClaim is an example of a CRD that a template stack may want to watch
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SampleClaimSpec defines some configuration that will be passed to the resource engine run by the template stack controller
+          type: object
+        status:
+          description: SampleClaimStatus tracks the state of the operations executed by the template stack controller
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test/helm2/stack.yaml
+++ b/test/helm2/stack.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: helm.samples.stacks.crossplane.io/v1alpha1
+kind: StackConfiguration
+metadata:
+  name: template-stack-test
+
+spec:
+  behaviors:
+    crds:
+      SampleClaim.samples.stacks.crossplane.io/v1alpha1:
+        hooks:
+          reconcile:
+          - directory: 'resources'
+    engine:
+      type: helm2
+    source:
+      image: crossplane/sample-stack-claim-test:helm2


### PR DESCRIPTION
## Overview

The render phase controller was becoming overly large and a bit hard to read, so it was about time to refactor it a little bit. Also, @muvaf's upcoming work on adding another engine type means that it'd be helpful to have a better contract for decoupling the resource engine logic from the controller flow.

This change aims to do two things:

* Introduce a new, cleaner contract for resource engines (this is also the first pass at the contract)
* Move resource engine logic out of the render controller so that it isn't cluttering things up for readers and maintainers

The commits in the PR should tell a relatively reasonable story about how this happened. But, to summarize, most of the changes are refactoring and moving the existing logic behind the interface. There's also a minor change to inject the name of the render controller's stack configuration in at the time it's created; previously it was being assumed to be the same as the claim that was being processed, which isn't going to work for real use-cases.

## Testing done

I've been testing this locally similar to the previous PRs. The gist of it is:

* Create a StackConfiguration by hand
* Create an object mentioned in that StackConfiguration (I've been using `HelmChartInstall`)
* `make run`
* Check that the jobs ran successfully and objects were created

Pretty soon I plan to investigate the [integration testing offered by controller-runtime](https://godoc.org/sigs.k8s.io/controller-runtime#hdr-Testing), but I haven't quite gotten around to it yet.

## Future work

As was noted in an earlier PR, there is some hardening that will be needed for the render controller. None of it is included in this PR.

* [ ] Only create one render controller per CRD. Currently one per CRD is created for every Reconcile call in the setup controller.
* [ ] Stop render controllers when they're no longer needed.
* [ ] Only create resources when it's needed, rather than blindly on every reconcile.